### PR TITLE
Graft add login form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,28 +6,20 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    coderay (1.1.1)
     concurrent-ruby (1.0.5)
-    daemons (1.2.4)
     database_cleaner (1.6.1)
     diff-lcs (1.3)
     docile (1.1.5)
     etna (0.1)
       extlib
       rack
-    eventmachine (1.2.5)
     extlib (0.9.16)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     i18n (0.8.6)
     json (2.1.0)
-    method_source (0.8.2)
     minitest (5.10.3)
     pg (0.21.0)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
     rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -50,11 +42,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slop (3.6.0)
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -68,13 +55,11 @@ DEPENDENCIES
   extlib
   factory_girl
   pg
-  pry
   rack
   rack-test
   rspec
   sequel
   simplecov
-  thin
 
 RUBY VERSION
    ruby 2.2.2p95

--- a/lib/client/css/login.css
+++ b/lib/client/css/login.css
@@ -1,0 +1,73 @@
+#login-group {
+
+  position: absolute;
+  width: 240px;
+  left: -120px;
+  margin-left: 50%;
+  margin-top: 20px;
+  padding-bottom: 10px;
+  border: 1px solid #999;
+}
+
+.log-input {
+
+  width: 200px;
+  height: 35px;
+  border: 1px solid #999;
+  margin-top: 10px;
+  margin-left: 20px;
+  text-indent: 5px;
+  font-family: 'gotham_bookregular';
+  outline: none;
+}
+
+.log-input:focus {
+
+  border: 1px solid #7db4b5;
+  outline: none;
+}
+
+.log-input:hover,
+.log-input:focus {
+
+  -webkit-box-shadow: inset -1px 1px 1px 0px #ccc;  /* Safari 3-4, iOS 4.0.2 - 4.2, Android 2.3+ */
+  -moz-box-shadow:    inset -1px 1px 1px 0px #ccc;  /* Firefox 3.5 - 3.6 */
+  box-shadow:         inset -1px 1px 1px 0px #ccc;
+}
+
+.login-button { 
+  
+  position: relative;
+  padding: 5px;
+  border: 1px solid #666;
+  border-radius: 1px;
+  background: #999;
+  cursor: pointer;
+  margin-top: 15px;
+  margin-left: 20px;
+  width: 200px;
+
+  color: #fff;
+  font-family: 'gotham_bookregular';
+  font-size: 1em;
+  letter-spacing: 1px;
+}
+
+.login-button:focus {
+    
+  outline:none;
+  border:1px solid #7db4b5;
+  background: #ccc;
+}
+
+.log-error-message {
+
+  display: none;
+  width: 200px;
+  height: 20px;
+  margin-left: 20px;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  font-size: 1em;
+  font-family: 'gotham_bookregular';
+}

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -3,8 +3,8 @@ class Janus
   class Server < Etna::Server
     get '/', 'client#index'
 
-    get '/login', 'user_log#log_in_shib'
-    post '/login', 'user_log#log_in'
+    get '/login', 'user_log#login'
+    post '/login', 'user_log#validate_login'
     post '/logout', 'user_log#log_out'
     post '/check', 'user_log#check_log'
 

--- a/lib/server/controllers/admin_controller.rb
+++ b/lib/server/controllers/admin_controller.rb
@@ -1,15 +1,4 @@
 class AdminController < Janus::Controller
-  def validate_admin_status
-    # Check that an 'app_key' is present and valid
-    raise Etna::BadRequest, 'Invalid app key' unless app_key_valid?
-
-    # Check if a token is present and valid.
-    raise Etna::BadRequest, 'Invalid token' unless token_valid?
-
-    # Get and check user and then check the token.
-    raise Etna::BadRequest, 'User is not an admin' unless token.user && token.user.admin?
-  end
-
   def check_admin_token
     validate_admin_status
 
@@ -84,5 +73,18 @@ class AdminController < Janus::Controller
     validate_admin_status
 
     success_json(success: true, logout_count: Janus::Token.expire_all!)
+  end
+
+  private
+
+  def validate_admin_status
+    # Check that an 'app_key' is present and valid
+    raise Etna::BadRequest, 'Invalid app key' unless app_key_valid?
+
+    # Check if a token is present and valid.
+    raise Etna::BadRequest, 'Invalid token' unless token_valid?
+
+    # Get and check user and then check the token.
+    raise Etna::BadRequest, 'User is not an admin' unless token.user && token.user.admin?
   end
 end

--- a/lib/server/controllers/janus_controller.rb
+++ b/lib/server/controllers/janus_controller.rb
@@ -7,10 +7,18 @@ class Janus
       @token = nil
     end
 
+    private
+
     def success_json(hash = {})
       success('application/json', hash.to_json)
     end
 
+    # token comes from params but should probably come from headers
+    def token
+      @token ||= Janus::Token[token: @params[:token]]
+    end
+
+    # Janus only takes requests from authorized applications
     def app_key_valid?
       @params.key?(:app_key) && app_valid?(@params[:app_key])
     end
@@ -24,10 +32,6 @@ class Janus
     # Checks for the user token and makes sure that the user token is valid.
     def token_valid?
       @params.key?(:token) && token && token.valid?
-    end
-
-    def token
-      @token ||= Janus::Token[token: @params[:token]]
     end
 
     # Quick check that the email is in a somewhat valid format.

--- a/lib/server/controllers/janus_controller.rb
+++ b/lib/server/controllers/janus_controller.rb
@@ -1,49 +1,24 @@
 class Janus
   class Controller < Etna::Controller
+    VIEW_PATH=File.expand_path('../views', __dir__)
+
     def initialize(request, action)
       super
       @token = nil
-    end
-
-    def default_checks
-    end
-
-    def response
-      default_checks
-      return send(@action)
-    rescue Etna::BadRequest => e
-      return failure(422, e.message)
-    rescue Etna::ServerError => e
-      return failure(500, e.message)
     end
 
     def success_json(hash = {})
       success('application/json', hash.to_json)
     end
 
-    def view(name)
-      txt = File.read(File.expand_path("../views/#{name}.html", __dir__))
-      @response['Content-Type'] = 'text/html'
-      @response.write(txt)
-      @response.finish
-    end
-
-    def erb_view(name)
-      txt = File.read(File.expand_path("../views/#{name}.html.erb", __dir__))
-      @response['Content-Type'] = 'text/html'
-      @response.write(ERB.new(txt).result)
-      @response.finish
-    end
-
-    def check_app_key
-      raise Etna::BadRequest, 'Param not present: app_key' if !@params.key?(:app_key)
-      raise Etna::BadRequest, 'Invalid app key' if !app_valid?(@params[:app_key])
+    def app_key_valid?
+      @params.key?(:app_key) && app_valid?(@params[:app_key])
     end
 
     # Checks for the user email and password. This is used before a user token is
     # generated.
     def email_password_valid?
-      @params.key?(:email) && @params.key?(:pass) && email_valid?(@params[:email])
+      @params.key?(:email) && @params.key?(:password) && email_valid?(@params[:email])
     end
 
     # Checks for the user token and makes sure that the user token is valid.

--- a/lib/server/controllers/user_log_controller.rb
+++ b/lib/server/controllers/user_log_controller.rb
@@ -15,19 +15,6 @@ class UserLogController < Janus::Controller
     respond_with_cookie(refer)
   end
 
-  def respond_with_cookie(user, refer)
-    # Set cookie and redirect.
-    @response.redirect(refer, 302)
-    @response.set_cookie(
-      Janus.instance.config(:token_name),
-      value: user.valid_token.token,
-      path: '/',
-      domain: Janus.instance.config(:token_domain),
-      expires: Time.now+Janus.instance.config(:token_life)
-    )
-    return @response.finish
-  end
-
   def login
     @refer = @params[:refer]
     erb_view(:login_form)
@@ -64,6 +51,19 @@ class UserLogController < Janus::Controller
   end
 
   private
+
+  def respond_with_cookie(user, refer)
+    # Set cookie and redirect.
+    @response.redirect(refer, 302)
+    @response.set_cookie(
+      Janus.instance.config(:token_name),
+      value: user.valid_token.token,
+      path: '/',
+      domain: Janus.instance.config(:token_domain),
+      expires: Time.now+Janus.instance.config(:token_life)
+    )
+    return @response.finish
+  end
 
   def extract_refer(query_string='')
     return nil if query_string.empty?

--- a/lib/server/controllers/user_log_controller.rb
+++ b/lib/server/controllers/user_log_controller.rb
@@ -1,17 +1,4 @@
 class UserLogController < Janus::Controller
-  def default_checks
-    check_app_key
-
-    case @action
-    when 'log_in'
-      unless email_password_valid?
-        raise Etna::BadRequest, 'Invalid login or password'
-      end
-    else
-      raise Etna::BadRequest, 'Invalid token' unless token_valid?
-    end
-  end
-
   def log_in_shib
     # Check that this request came from shibboleth(shibd).
     email = @request.env['HTTP_X_SHIB_ATTRIBUTE'].downcase
@@ -25,11 +12,15 @@ class UserLogController < Janus::Controller
     # Create a new token for the user.
     user.create_token!
 
+    respond_with_cookie(refer)
+  end
+
+  def respond_with_cookie(user, refer)
     # Set cookie and redirect.
     @response.redirect(refer, 302)
     @response.set_cookie(
       Janus.instance.config(:token_name),
-      value: user.valid_token,
+      value: user.valid_token.token,
       path: '/',
       domain: Janus.instance.config(:token_domain),
       expires: Time.now+Janus.instance.config(:token_life)
@@ -37,11 +28,16 @@ class UserLogController < Janus::Controller
     return @response.finish
   end
 
-  def log_in
+  def login
+    @refer = @params[:refer]
+    erb_view(:login_form)
+  end
 
+  def validate_login
+    raise Etna::BadRequest, 'Invalid login or password' unless email_password_valid?
     # Get and check user and then check the password.
     user = Janus::User[email: @params[:email]]
-    unless user && user.authorized?(@params[:pass])
+    unless user && user.authorized?(@params[:password])
       raise Etna::BadRequest, 'Invalid login'
     end
 
@@ -49,12 +45,16 @@ class UserLogController < Janus::Controller
     user.create_token!
 
     # On success return the user info.
-    success_json(success: true, user_info: user.to_hash)
+    respond_with_cookie(user, @params[:refer])
   end
 
   def check_log
+    raise Etna::BadRequest, 'Invalid app key' unless app_key_valid?
+
+    raise Etna::BadRequest, 'Invalid token' unless token_valid?
+
     # Pull the user info for the token.
-    success_json(success: true, user_info: token.user.to_hash)
+    success_json(token.user.to_hash)
   end
 
   def log_out

--- a/lib/server/models/user.rb
+++ b/lib/server/models/user.rb
@@ -9,7 +9,7 @@ class Janus
         first_name: first_name, 
         last_name: last_name, 
         user_id: id,
-        token: valid_token,
+        token: valid_token.token,
         permissions:  permissions.map do |permission|
           {
             role: permission.role,
@@ -39,7 +39,7 @@ class Janus
     end
 
     def valid_token
-      tokens.find(&:valid?)[:token]
+      tokens.find(&:valid?)
     end
 
     def valid_tokens

--- a/lib/server/views/login_form.html.erb
+++ b/lib/server/views/login_form.html.erb
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Janus Auth Server
+    </title>
+    <link type='text/css' rel='stylesheet' href='/css/reset.css' />
+    <link type='text/css' rel='stylesheet' href='/css/bootstrap.min.css' />
+    <link type='text/css' rel='stylesheet' href='/css/fonts.css' />
+    <link type='text/css' rel='stylesheet' href='/css/global.css' />
+    <link type='text/css' rel='stylesheet' href='/css/login.css' />
+    <link type='text/css' rel='stylesheet' href='/css/media.css' />
+    <link rel="icon"  type="image/png"  href="/img/favicon.png">
+  </head>
+  <body>
+    <div id='ui-group'>
+      <div id='janus-group'>
+        <div id='header-group'>
+          <div id='title-menu'>
+            <button class='title-menu-btn'>
+                Janus
+              <br />
+              <span>
+                AUTHSERVER
+              </span>
+            </button>
+            <img id='ucsf-logo' src='/img/ucsf_logo_dark.png' alt='' />
+          </div>
+          <div id='nav-menu'>
+          </div>
+        </div>
+        <div class='logo-group'>
+          <img src='/img/logo_basic.png' alt='' />
+        </div>
+        <div id='left-column-group'>
+        </div>
+        <form id='login-group' method='post' action='/login'>
+          <input type='hidden' name='refer' value='<%= @refer %>'/>
+          <input name='email' id='email-input' class='log-input' type='text' placeholder='Enter your email'/>
+          <br />
+          <input name='password' id='pass-input' class='log-input' type='password' placeholder='Enter your password' />
+          <br />
+          <input type='submit' class='login-button' value='SIGN IN'/>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'json'
+require 'uri'
 require 'simplecov'
 require 'factory_girl'
 require 'database_cleaner'
@@ -154,6 +155,16 @@ def json_post endpoint, hash
     hash.to_json,
     {
       'CONTENT_TYPE' => 'application/json'
+    }
+  )
+end
+
+def form_post endpoint, hash
+  post(
+    "/#{endpoint}",
+    URI.encode_www_form(hash),
+    {
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
     }
   )
 end


### PR DESCRIPTION
1. Adds a simple html login form using an ERB template, via GET /login. POSTs to /login. Redirects back to referrer and sets a JANUS_TOKEN as a Cookie. 

2. Depends on https://github.com/mountetna/etna/pull/1 and implements those interface changes (mostly deleting code)

3. I have been generally favoring not using "before_filter"-style hidden checks in controllers, favoring explicit calls of all validations in the controller actions instead. Also where possible I have been using "raise" in controller actions to return errors, rather than raising exceptions in other methods - Etna::Controller by default rescues the two main Etna::Error classes and returns a JSON error with them. 