### PR TITLE
set expiration time correctly based on token

### DIFF
--- a/lib/models/user.rb
+++ b/lib/models/user.rb
@@ -22,11 +22,11 @@ class User < Sequel::Model
   # WARNING! In the event of a shibboleth login 'pass_hash' == nil!
   def create_token!
     # Time is in seconds, nil = no expiration
-    expires = Time.now + Janus.instance.config(:token_life)
+    expires = Time.now.utc + Janus.instance.config(:token_life)
 
     add_token(
       token: Token.generate, 
-      token_login_stamp: Time.now,
+      token_login_stamp: Time.now.utc,
       token_expire_stamp: expires,
       token_logout_stamp: expires
     )

--- a/lib/models/user.rb
+++ b/lib/models/user.rb
@@ -1,6 +1,6 @@
 class User < Sequel::Model
   one_to_many :permissions
-  one_to_many :tokens
+  one_to_many :tokens, order: Sequel.desc(:token_login_stamp)
 
   def to_hash
     {

--- a/lib/server/controllers/user_log_controller.rb
+++ b/lib/server/controllers/user_log_controller.rb
@@ -25,7 +25,7 @@ class UserLogController < Janus::Controller
     @refer = @params[:refer]
 
     # Check if the token is set. If not then show the login dialog.
-    @params[:token] = pull_token_from_cookie
+    @params[:token] = @request.cookies[Janus.instance.config(:token_name)]
 
     # Check if the token is valid. If not then show the login dialog.
     return erb_view(:login_form) unless token_valid?
@@ -124,21 +124,5 @@ class UserLogController < Janus::Controller
 
     # Check to make sure the refer comes from the same domain as the token.
     return host == Janus.instance.config(:token_domain) ? true : false
-  end
-
-  # Check to see if there is a Janus cookie set, and if it is valid.
-  def pull_token_from_cookie
-    tkn = nil
-    return tkn unless @request.env['HTTP_COOKIE']
-
-    cookies = @request.env['HTTP_COOKIE'].split(';')
-    cookies.each do |cookie|
-      if cookie.include?(Janus.instance.config(:token_name))
-        tkn = cookie.split('=')[1]
-        break
-      end
-    end
-
-    return tkn
   end
 end

--- a/lib/server/controllers/user_log_controller.rb
+++ b/lib/server/controllers/user_log_controller.rb
@@ -26,10 +26,9 @@ class UserLogController < Janus::Controller
 
     # Check if the token is set. If not then show the login dialog.
     @params[:token] = pull_token_from_cookie
-    return erb_view(:login_form) if !token
 
     # Check if the token is valid. If not then show the login dialog.
-    return erb_view(:login_form) if !token_valid?
+    return erb_view(:login_form) unless token_valid?
 
     # Make sure the refer url is valid.
     unless refer_valid?(@params[:refer])
@@ -37,7 +36,9 @@ class UserLogController < Janus::Controller
     end
 
     # The token is valid and the refer is ok, so go ahead and redirect the user.
-    respond_with_cookie(token.user, @refer)
+    @response.redirect(@params[:refer], 302)
+
+    @response.finish
   end
 
   def validate_login
@@ -88,7 +89,7 @@ class UserLogController < Janus::Controller
       value: user.valid_token.token,
       path: '/',
       domain: Janus.instance.config(:token_domain),
-      expires: Time.now+Janus.instance.config(:token_life)
+      expires: user.valid_token.token_expire_stamp
     )
 
     return @response.finish

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -8,8 +8,9 @@ describe UserLogController do
     @client = create(:app, app_name: 'test', app_key: 'THE KEY')
   end
 
-  context "password login" do
+  context 'password login' do
     before(:each) do
+      @refer = "https://#{Janus.instance.config(:token_domain)}"
       @password = 'password'
       @user = create(
         :user,
@@ -18,47 +19,90 @@ describe UserLogController do
       )
     end
 
-    it "gets a simple form" do
-      refer = 'http://test.st'
-      get("/login?refer=#{refer}")
+    it 'gets a simple form' do
+      get("/login?refer=#{@refer}")
 
       expect(last_response.status).to eq(200)
-      expect(last_response.body).to match(/value='#{refer}'/)
+      expect(last_response.body).to match(/value='#{@refer}'/)
     end
 
-    it "complains without credentials" do
+    it 'redirects with a valid cookie' do
+      token = create( :token, user: @user, token: 'xyzzy',
+                     token_expire_stamp: Time.now+60,
+                     token_logout_stamp: Time.now+60)
+      set_cookie([ Janus.instance.config(:token_name), token.token ].join('='))
+
+      get("/login?refer=#{@refer}")
+
+      expect(last_response.status).to eq(302)
+      expect(last_response.headers['Location']).to eq(@refer)
+      expect(@user.valid_token).not_to be_nil
+    end
+
+    it 'complains without credentials' do
       json_post( 'validate-login', {} )
       expect(last_response.status).to eq(422)
     end
 
-    it "validates a password" do
+    it 'validates a password' do
       form_post(
         'validate-login', 
         email: @user.email,
         password: 'bassboard',
-        app_key: @client.app_key
+        app_key: @client.app_key,
+        refer: @refer
       )
       expect(last_response.status).to eq(422)
     end
 
-    it "redirects to refer with credentials" do
-      refer = "https://#{Janus.instance.config(:token_domain)}"
+    it 'sets a cookie with the token on success' do
+      form_post(
+        'validate-login', 
+        email: @user.email,
+        password: 'password',
+        app_key: @client.app_key,
+        refer: @refer
+      )
+      cookies = parse_cookie(last_response.headers['Set-Cookie'])
+      expect(cookies[Janus.instance.config(:token_name)]).not_to be_nil
+      expect(last_response.status).to eq(302)
+    end
+
+    it 'sets the expiration time on the cookie correctly' do
+      form_post(
+        'validate-login', 
+        email: @user.email,
+        password: 'password',
+        app_key: @client.app_key,
+        refer: @refer
+      )
+      @user.refresh
+      token = @user.valid_token
+      cookies = parse_cookie(last_response.headers['Set-Cookie'])
+      cookie_time = Time.parse(cookies['expires'])
+
+      expect(cookies[Janus.instance.config(:token_name)]).not_to be_nil
+      expect(cookie_time).to be_within(1).of(token.token_expire_stamp)
+      expect(last_response.status).to eq(302)
+    end
+
+    it 'redirects to refer with credentials' do
       form_post(
         'validate-login', 
         email: @user.email,
         password: @password,
         app_key: @client.app_key,
-        refer: refer
+        refer: @refer
       )
 
       expect(last_response.status).to eq(302)
-      expect(last_response.headers["Location"]).to eq(refer)
+      expect(last_response.headers['Location']).to eq(@refer)
       expect(@user.valid_token).not_to be_nil
     end
   end
 
-  context "logout" do
-    it "logs the user out" do
+  context 'logout' do
+    it 'logs the user out' do
       user = create( :user, email: 'janus@mount.etna' )
       token = create( :token, user: user, token: 'xyzzy',
                      token_expire_stamp: Time.now+60,
@@ -73,8 +117,8 @@ describe UserLogController do
     end
   end
 
-  context "check_log" do
-    it "returns user information for a token" do
+  context 'check_log' do
+    it 'returns user information for a token' do
       user = create( :user, email: 'janus@mount.etna' )
       token = create( :token, user: user, token: 'xyzzy',
                      token_expire_stamp: Time.now+60,
@@ -85,7 +129,7 @@ describe UserLogController do
                 app_key: @client.app_key)
 
       json = JSON.parse(last_response.body)
-      expect(json["email"]).to eq(user.email)
+      expect(json['email']).to eq(user.email)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -176,3 +176,7 @@ end
 def config
   Janus.instance.instance_variable_get("@config")
 end
+
+def parse_cookie set_cookie
+  Hash[set_cookie.split(/; /).map { |param| param.split(/=/) }]
+end


### PR DESCRIPTION
I continue to have no_auth issues, which I think are due to this bug, which sets the cookie expiration time through a new calculation rather than from the token_expire_stamp and more importantly uses the newest created token (previously valid_token would return the oldest currently valid token).

I still suspect we will continue to have issues with this somehow, the various clock-sync issues are insidious.