### PR TITLE
Graft fix login

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ This endpoint is mostly useful for developers.
 
 The `/login` endpoint can also be configured as a Shibboleth-protected endpoint
 for authentication. If successful, Janus will set a cookie with the token in
-the response. This endpoint is most suitable for browser applications.
+the response. This endpoint is most suitable for browser applications. To use
+this method for authentication, set `auth_method: shibboleth` in the configuration.
+
 
 ## Public-key login
 
@@ -111,6 +113,9 @@ Example:
 
     # We recommend using the 'private' search path
     :search_path: [ private ]
+
+  # Use Shibboleth to authenticate logins
+  auth_method: shibboleth
 
   # How Janus should generate passwords (using Etna::SignService)
   :pass_algo: sha256

--- a/lib/server/controllers/admin_controller.rb
+++ b/lib/server/controllers/admin_controller.rb
@@ -72,11 +72,15 @@ class AdminController < Janus::Controller
   private
 
   def validate_admin_status
+    app = App[app_key: @params[:app_key]]
+
     # Check that an 'app_key' is present and valid.
-    raise Etna::BadRequest, 'Invalid app key' unless app_key_valid?
+    raise Etna::BadRequest, 'Invalid app key' unless app
 
     # Check if a token is present and valid.
-    raise Etna::BadRequest, 'Invalid token' unless token_valid?
+    token = Token[token: @params[:token]]
+
+    raise Etna::BadRequest, 'Invalid token' unless token && token.valid?
 
     # Get and check user and then check the token.
     raise Etna::BadRequest, 'User is not an admin' unless token.user && token.user.admin?

--- a/lib/server/controllers/authorization_controller.rb
+++ b/lib/server/controllers/authorization_controller.rb
@@ -3,8 +3,7 @@ require_relative '../nonce'
 class AuthorizationController < Janus::Controller
   def login_shib
     # Make sure the refer url is valid.
-    refer = extract_refer(@request.env['QUERY_STRING'])
-    if refer.nil? || !refer_valid?(refer)
+    unless refer_valid?(@params[:refer])
       raise Etna::BadRequest, 'Invalid url refer'
     end
 
@@ -26,15 +25,15 @@ class AuthorizationController < Janus::Controller
     @refer = @params[:refer]
 
     # Check if the token is set. If not then show the login dialog.
-    @params[:token] = @request.cookies[Janus.instance.config(:token_name)]
+    token = Token[token: @request.cookies[Janus.instance.config(:token_name)]]
 
     # Check if the token is valid. If not then show the login dialog.
-    return erb_view(:login_form) unless token_valid?
 
     # Make sure the refer url is valid.
     unless refer_valid?(@params[:refer])
       raise Etna::BadRequest, 'Invalid url refer' 
     end
+    return erb_view(:login_form) unless token && token.valid?
 
     # The token is valid and the refer is ok, so go ahead and redirect the user.
     @response.redirect(@params[:refer], 302)
@@ -43,13 +42,15 @@ class AuthorizationController < Janus::Controller
   end
 
   def validate_login
-    unless email_password_valid?
-      raise Etna::BadRequest, 'Invalid email or password' 
+    require_params(:email, :password)
+
+    unless email_valid?(@params[:email])
+     raise Etna::BadRequest, 'Invalid email'
     end
 
     # Make sure the refer url is valid.
     unless refer_valid?(@params[:refer])
-      raise Etna::BadRequest, 'Invalid url refer' 
+      raise Etna::BadRequest, 'Invalid url refer'
     end
 
     # Get and check user and then check the password.
@@ -67,8 +68,13 @@ class AuthorizationController < Janus::Controller
   end
 
   def check_log
-    raise Etna::BadRequest, 'Invalid app key' unless app_key_valid?
-    raise Etna::BadRequest, 'Invalid token' unless token_valid?
+    app = App[app_key: @params[:app_key]]
+
+    raise Etna::BadRequest, 'Invalid app key' unless app
+
+    token = Token[token: @params[:token]]
+
+    raise Etna::BadRequest, 'Invalid token' unless token && token.valid?
 
     # Pull the user info for the token.
     success_json(token.user.to_hash)
@@ -76,6 +82,7 @@ class AuthorizationController < Janus::Controller
 
   def log_out
     # Invalidate the token.
+    token = Token[token: @params[:token]]
     token.invalidate!
     success_json(success: true, logged: false)
   end
@@ -92,7 +99,7 @@ class AuthorizationController < Janus::Controller
   def generate
     # The user must authorize the request with
     # their signature
-    
+
     auth_token = (@request.env['HTTP_AUTHORIZATION'] || '')[ /\ASigned-Nonce (.*)\z/, 1 ]
 
     return failure(401, 'Validation token was not presented.') unless auth_token
@@ -114,7 +121,7 @@ class AuthorizationController < Janus::Controller
 
     # check the user's signature
     unless user.valid_signature?("#{timesig64}.#{email64}", Base64.decode64(signature64))
-      return failure(401, noauth) 
+      return failure(401, noauth)
     end
 
     user.create_token!
@@ -138,34 +145,14 @@ class AuthorizationController < Janus::Controller
     return @response.finish
   end
 
-  def extract_refer(query_string='')
-    return nil if query_string.empty?
-
-    # Split the string on '&' and '='.
-    query_hash = Hash[
-      URI.unescape(query_string).split('&').map { |i| i.split(/=/) }
-    ]
-
-    # Check for 'refer' key.
-    return nil unless query_hash.key?('refer')
-
-    # Check that the refer url is valid and in our Mt. Etna network.
-    return nil unless refer_valid?(query_hash['refer'])
-
-    return query_hash['refer']
-  end
-
   def refer_valid?(refer)
-
     # Attempt to parse the refer.
-    begin
-      uri = URI.parse(refer)
-      host = uri.host.split('.')[-2,2].join('.') # Extract the root host.
-    rescue
-      return false
-    end
+    uri = URI.parse(refer)
+    host = uri.host.split('.')[-2,2].join('.') # Extract the root host.
 
     # Check to make sure the refer comes from the same domain as the token.
-    return host == Janus.instance.config(:token_domain) ? true : false
+    host == Janus.instance.config(:token_domain) ? true : false
+  rescue
+    return false
   end
 end

--- a/lib/server/controllers/janus_controller.rb
+++ b/lib/server/controllers/janus_controller.rb
@@ -13,37 +13,9 @@ class Janus
       success(hash.to_json, 'application/json')
     end
 
-    # Token comes from params but should probably come from headers.
-    def token
-      @token ||= Token[token: @params[:token]]
-    end
-
-    # Janus only takes requests from authorized applications.
-    def app_key_valid?
-      @params.key?(:app_key) && app_valid?(@params[:app_key])
-    end
-
-    # Checks for the user email and password. This is used before a user token
-    # is generated.
-    def email_password_valid?
-      @params.key?(:email) &&
-      @params.key?(:password) &&
-      email_valid?(@params[:email])
-    end
-
-    # Checks for the user token and makes sure that the user token is valid.
-    def token_valid?
-      @params.key?(:token) && token && token.valid?
-    end
-
     # Quick check that the email is in a somewhat valid format.
     def email_valid?(eml)
       eml =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/
-    end
-
-    # Check to see if the application key is valid.
-    def app_valid?(app_key)
-      return App[app_key: app_key]
     end
   end
 end

--- a/lib/server/views/login_form.html.erb
+++ b/lib/server/views/login_form.html.erb
@@ -46,7 +46,7 @@
         </div>
         <form id='login-group' method='post' action='/validate-login'>
 
-          <input type='hidden' name='refer' value='<%= @refer %>' />
+          <input type='hidden' name='refer' value='<%= @params[:refer] %>' />
           <input name='email' id='email-input' class='log-input' type='text' placeholder='Enter your email' />
           <br />
           <input name='password' id='pass-input' class='log-input' type='password' placeholder='Enter your password' />


### PR DESCRIPTION
This unifies the #login and #login_shib methods into the /login endpoint, allowing us to set 'auth_method: shibboleth' in config.yml and avoid having to edit lib/server.rb when we deploy.