### PR TITLE
jc-remove-old-tables

### DIFF
--- a/db/migrations/004_drop_unused_tables.rb
+++ b/db/migrations/004_drop_unused_tables.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    alter_table(:projects) do
+      drop_column :group_id
+    end
+    drop_table(:apps)
+    drop_table(:groups)
+  end
+end

--- a/lib/models.rb
+++ b/lib/models.rb
@@ -1,5 +1,3 @@
-require_relative 'models/app'
-require_relative 'models/group'
 require_relative 'models/permission'
 require_relative 'models/project'
 require_relative 'models/token'

--- a/lib/models/app.rb
+++ b/lib/models/app.rb
@@ -1,2 +1,0 @@
-class App < Sequel::Model
-end

--- a/lib/models/group.rb
+++ b/lib/models/group.rb
@@ -1,3 +1,0 @@
-class Group < Sequel::Model
-  one_to_many :projects
-end

--- a/lib/models/project.rb
+++ b/lib/models/project.rb
@@ -1,12 +1,8 @@
 class Project < Sequel::Model
   one_to_many :permissions
-  many_to_one :group
 
   def to_hash
     {
-      project_id: id,
-      group_id: group_id,
-      group_name: group.group_name,
       project_name: project_name,
       project_name_full: project_name_full
     }


### PR DESCRIPTION
Removing old models and table no longer required. Specifically the 'apps' tables for the 'app_key'.