### PR TITLE
Update Ruby to 2.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,12 @@
 source 'https://rubygems.org'
 
-ruby '2.2.2'
+ruby '2.5.1'
 
 gem 'rack'
 gem 'rack-throttle'
 gem 'pg'
 gem 'sequel'
 gem 'etna'
-gem 'extlib'
 gem 'jwt'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -10,45 +10,42 @@ GEM
     concurrent-ruby (1.0.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
-    docile (1.3.0)
-    etna (0.1.2)
-      extlib
+    docile (1.3.1)
+    etna (0.1.3)
       jwt
       rack
-    extlib (0.9.16)
-    factory_bot (4.8.2)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    i18n (1.0.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     jwt (2.1.0)
     method_source (0.9.0)
     minitest (5.11.3)
-    pg (1.0.0)
+    pg (1.1.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    puma (3.11.4)
     rack (2.0.5)
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rack-throttle (0.5.0)
+    rack-throttle (0.6.0)
       bundler (>= 1.0.0)
       rack (>= 1.0.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    sequel (5.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    sequel (5.13.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -65,12 +62,10 @@ PLATFORMS
 DEPENDENCIES
   database_cleaner
   etna
-  extlib
   factory_bot
   jwt
   pg
   pry
-  puma
   rack
   rack-test
   rack-throttle
@@ -80,7 +75,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.2.2p95
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.14.6
+   1.16.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.on_potential_false_positives = :nothing
   end
 
   # rspec-mocks config goes here. You can use an alternate test double
@@ -102,7 +103,6 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
@@ -110,6 +110,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  config.order = :random
 
   config.include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
Updates Janus to use Ruby 2.5.1. There were no issues updating here, following an updated etna gem. This should consequently depend on the corresponding etna PR closing first