### PR TITLE
Update permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :test do
   gem 'rack-test', require: "rack/test"
   gem 'factory_bot'
   gem 'simplecov'
+  gem 'nokogiri'
   gem 'pry'
   gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,10 @@ GEM
     json (2.2.0)
     jwt (2.2.1)
     method_source (0.9.2)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     pg (1.1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -64,6 +67,7 @@ DEPENDENCIES
   etna
   factory_bot
   jwt
+  nokogiri
   pg
   pry
   rack

--- a/db/migrations/005_add_affiliation_to_permission.rb
+++ b/db/migrations/005_add_affiliation_to_permission.rb
@@ -1,0 +1,7 @@
+Sequel.migration do 
+  change do
+    alter_table(:permissions) do
+      add_column :affiliation, String
+    end
+  end
+end

--- a/lib/client/scss/project.scss
+++ b/lib/client/scss/project.scss
@@ -29,6 +29,14 @@
     padding: 15px 7px 0px 7px;
     font-size: 0.9em;
   }
+
+  .filter {
+    width: 400px;
+  }
+  .items {
+    max-height: 410px;
+    overflow: auto;
+  }
   .item {
     display: flex;
     align-items: center;

--- a/lib/models/permission.rb
+++ b/lib/models/permission.rb
@@ -8,6 +8,7 @@ class Permission < Sequel::Model
       user_id: user_id,
       project_id: project_id,
       role: role,
+      affiliation: affiliation,
       project_name: project.project_name,
       user_email: user.email,
       group_id: project.group_id,

--- a/lib/models/permission.rb
+++ b/lib/models/permission.rb
@@ -25,6 +25,10 @@ class Permission < Sequel::Model
     role == 'administrator'
   end
 
+  def editor?
+    role == 'editor' || admin?
+  end
+
   def project_role
     [ role_key, project.project_name ]
   end

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -20,7 +20,7 @@ class Janus
 
     get '/', action: 'admin#main'
 
-    get '/project/:project_name', action: 'admin#project', auth: { user: { is_admin?: :project_name } }
+    get '/project/:project_name', action: 'admin#project', auth: { user: { can_edit?: :project_name } }
 
     post '/update_permission/:project_name', action: 'admin#update_permission', auth: { user: { is_admin?: :project_name } }
 

--- a/lib/server/controllers/admin_controller.rb
+++ b/lib/server/controllers/admin_controller.rb
@@ -6,7 +6,16 @@ class AdminController < Janus::Controller
 
   def project
     @project = Project[project_name: @params[:project_name]]
-    @roles = @user.is_superuser? ? [ 'administrator', 'viewer', 'editor', 'disabled' ] : [ 'viewer', 'editor', 'disabled' ]
+    @static = nil
+    if @user.is_superuser?
+      @roles = [ 'administrator', 'viewer', 'editor', 'disabled' ]
+    elsif @user.is_admin?(@params[:project_name])
+      @roles = [ 'viewer', 'editor', 'disabled' ]
+    else
+      @roles = []
+      @static = true
+    end
+
     @project_roles = @project.permissions.group_by(&:role)
     erb_view(:project)
   end

--- a/lib/server/controllers/admin_controller.rb
+++ b/lib/server/controllers/admin_controller.rb
@@ -42,6 +42,7 @@ class AdminController < Janus::Controller
     else
       permission.role = @params[:role] if @params[:role]
       permission.privileged = @params[:privileged] if [true,false].include?(@params[:privileged])
+      permission.affiliation = @params[:affiliation] if @params[:affiliation]
       permission.save
     end
 
@@ -75,6 +76,7 @@ class AdminController < Janus::Controller
     permission = Permission.create(project: @project, user: user, role: @params[:role])
     permission.role = @params[:role] if [ 'viewer', 'editor' ].include?(@params[:role])
     permission.privileged = false
+    permission.affiliation = @params[:affiliation]
     permission.save
 
     @response.redirect("/project/#{@params[:project_name]}")

--- a/lib/server/views/main.html.erb
+++ b/lib/server/views/main.html.erb
@@ -15,7 +15,7 @@
           <div class='title'>Your Projects</div>
           <% @janus_user.permissions.sort_by{|p| p.role[0] + p.project.project_name_full.capitalize }.each do |permission| %>
             <div class='item'>
-              <% if permission.admin? || @janus_user.superuser? %>
+              <% if permission.editor? || @janus_user.superuser? %>
                 <a href='/project/<%= permission.project.project_name %>'>
                   <%= permission.project.project_name_full.capitalize %>
                 </a>

--- a/lib/server/views/project.html.erb
+++ b/lib/server/views/project.html.erb
@@ -4,12 +4,10 @@
   <%= erb_partial(:header) %>
   <script type='text/javascript'>
 
-const show = (form) => form.querySelectorAll('i').forEach(
-  e => e.style = 'display:inline;'
-);
-const hide = (form) => form.querySelectorAll('i').forEach(
-  e => e.style = 'display:none;'
-);
+const show = (e,type='inline') => e.style = `display:${type};`;
+const hide = (e) => e.style = 'display:none;';
+const showForm = (form) => form.querySelectorAll('i').forEach(i =>show(i));
+const hideForm = (form) => form.querySelectorAll('i').forEach(hide);
 
 const INPUTS = {
   select: {
@@ -59,8 +57,8 @@ const updatePermission = function(e) {
   let select = e.target;
   let form = select.closest('.item');
 
-  if (inputsChanged(form, PERMISSION_INPUTS)) show(form);
-  else hide(form);
+  if (inputsChanged(form, PERMISSION_INPUTS)) showForm(form);
+  else hideForm(form);
 }
 
 const approveForm = function(e) {
@@ -75,7 +73,7 @@ const cancelPermission = function(e) {
   let form = select.closest('.item');
 
   resetInputs(form, PERMISSION_INPUTS);
-  hide(form);
+  hideForm(form);
 }
 
 const NEWUSER_INPUTS = {
@@ -87,8 +85,8 @@ const updateNewUser = function(e) {
   let select = e.target;
   let form = select.closest('.item');
 
-  if (inputsChanged(form, NEWUSER_INPUTS)) show(form);
-  else hide(form);
+  if (inputsChanged(form, NEWUSER_INPUTS)) showForm(form);
+  else hideForm(form);
 }
 
 const cancelNewUser = function(e) {
@@ -96,7 +94,23 @@ const cancelNewUser = function(e) {
   let form = select.closest('.item');
 
   resetInputs(form, NEWUSER_INPUTS);
-  hide(form);
+  hideForm(form);
+}
+
+const value = (item) => item.value || item.innerHTML;
+
+const filter = (e) => {
+  let filter = e.target.value;
+
+  let items = document.querySelectorAll('.items .item');
+  items.forEach(item => {
+    let columns = [ 'name', 'email', 'role', 'affiliation' ];
+    if (columns.some(value_class =>
+      value(item.querySelector(`.${value_class}`)).match(new RegExp(filter, 'i'))
+      )) {
+      show(item, 'flex');
+    } else hide(item);
+  })
 }
   </script>
   <body>
@@ -122,22 +136,28 @@ const cancelNewUser = function(e) {
             <div class='cell'>Privileged</div>
             <div class='cell submit'></div>
           </div>
+          <% if @project.permissions.size > 10 %>
+            <div class='item'>
+              <input class='filter' type='text' placeholder='Filter rows' name='filter' oninput='filter(event)'>
+            </div>
+          <% end %>
+          <div class='items'>
           <% @project.permissions.sort_by{|p| [ p.role, p.user.email ] }.each do |permission| %>
             <form method='post' action='/update_permission/<%= @project.project_name %>' class='item permission'>
-              <div class='cell'><%= permission.user.name %></div>
+              <div class='cell'><span class='name'><%= permission.user.name %></span></div>
               <div class='cell'>
                 <% if !@static %>
                   <input type='hidden' name='email' value='<%= permission.user.email %>'>
                 <% end %>
-                <%= permission.user.email %></div>
+                <span class='email'><%= permission.user.email %></span></div>
               <div class='cell'>
                 <% if !@static %>
                   <input type='hidden' name='original_role' value='<%= permission.role %>'>
                 <% end %>
                 <% unless @roles.include?(permission.role) %>
-                  <%= permission.role %>
+                  <span class='role'><%= permission.role %></span>
                 <% else %>
-                  <select name='role' oninput='updatePermission(event)'>
+                  <select class='role' name='role' oninput='updatePermission(event)'>
                     <% @roles.each do |role| %>
                       <option value='<%= role %>' <%= role == permission.role.to_s ? 'selected' : '' %>><%= role %></option>
                     <% end %>
@@ -147,9 +167,9 @@ const cancelNewUser = function(e) {
               <div class='cell'>
                 <% if !@static %>
                   <input type='hidden' name='original_affiliation' value='<%= permission.affiliation %>'>
-                  <input type='text' name='affiliation' value='<%= permission.affiliation %>' oninput='updatePermission(event)'>
+                  <input class='affiliation' type='text' name='affiliation' value='<%= permission.affiliation %>' oninput='updatePermission(event)'>
                 <% else %>
-                  <%= permission.affiliation %>
+                  <span class='affiliation'><%= permission.affiliation %></span>
                 <% end %>
               </div>
               <div class='cell'>
@@ -167,6 +187,7 @@ const cancelNewUser = function(e) {
               </div>
             </form>
           <% end %>
+          </div>
           <% if !@static %>
             <div class='new'>New User</div>
             <form method='post' action='/add_user/<%= @project.project_name %>' class='item'>

--- a/lib/server/views/project.html.erb
+++ b/lib/server/views/project.html.erb
@@ -111,10 +111,14 @@ const cancelNewUser = function(e) {
             <form method='post' action='/update_permission/<%= @project.project_name %>' class='item permission'>
               <div class='cell'><%= permission.user.name %></div>
               <div class='cell'>
-                <input type='hidden' name='email' value='<%= permission.user.email %>'>
+                <% if !@static %>
+                  <input type='hidden' name='email' value='<%= permission.user.email %>'>
+                <% end %>
                 <%= permission.user.email %></div>
               <div class='cell'>
-                <input type='hidden' name='original_role' value='<%= permission.role %>'>
+                <% if !@static %>
+                  <input type='hidden' name='original_role' value='<%= permission.role %>'>
+                <% end %>
                 <% unless @roles.include?(permission.role) %>
                   <%= permission.role %>
                 <% else %>
@@ -126,9 +130,13 @@ const cancelNewUser = function(e) {
                 <% end %>
               </div>
               <div class='cell'>
-                <input type='hidden' name='original_privileged' value='<%= permission.privileged? ? 'true' : 'false' %>'>
-                <input type='hidden' name='privileged' value='false'>
-                <input type='checkbox' name='privileged' value='true' <%= permission.privileged? ? 'checked' : '' %> onchange='updatePermission(event)'>
+                <% if @static %>
+                  <%= permission.privileged? ? 'Yes' : '' %>
+                <% else %>
+                  <input type='hidden' name='original_privileged' value='<%= permission.privileged? ? 'true' : 'false' %>'>
+                  <input type='hidden' name='privileged' value='false'>
+                  <input type='checkbox' name='privileged' value='true' <%= permission.privileged? ? 'checked' : '' %> onchange='updatePermission(event)'>
+                <% end %>
               </div>
               <div class='cell submit'>
                 <i class='approve fa fa-fw fa-save' style='display:none;' onclick='approveForm(event)'> </i>
@@ -136,23 +144,25 @@ const cancelNewUser = function(e) {
               </div>
             </form>
           <% end %>
-          <div class='new'>New User</div>
-          <form method='post' action='/add_user/<%= @project.project_name %>' class='item'>
-            <div class='cell'><input type='text' onchange='updateNewUser(event)' placeholder='Name' name='name'></div>
-            <div class='cell'><input type='text' onchange='updateNewUser(event)' placeholder='Email' name='email'></div>
-            <div class='cell'>
-              <select onchange='updateNewUser(event)' name='role'>
-                <option selected value='none'>Role</option>
-                <option value='viewer'>Viewer</option>
-                <option value='editor'>Editor</option>
-              </select>
-            </div>
-            <div class='cell'></div>
-            <div class='cell submit'>
-              <i class='approve fa fa-fw fa-save' style='display:none;' onclick='approveForm(event)'> </i>
-              <i class='cancel fa fa-fw fa-ban' style='display:none;' onclick='cancelNewUser(event)'> </i>
-            </div>
-          </form>
+          <% if !@static %>
+            <div class='new'>New User</div>
+            <form method='post' action='/add_user/<%= @project.project_name %>' class='item'>
+              <div class='cell'><input type='text' onchange='updateNewUser(event)' placeholder='Name' name='name'></div>
+              <div class='cell'><input type='text' onchange='updateNewUser(event)' placeholder='Email' name='email'></div>
+              <div class='cell'>
+                <select onchange='updateNewUser(event)' name='role'>
+                  <option selected value='none'>Role</option>
+                  <option value='viewer'>Viewer</option>
+                  <option value='editor'>Editor</option>
+                </select>
+              </div>
+              <div class='cell'></div>
+              <div class='cell submit'>
+                <i class='approve fa fa-fw fa-save' style='display:none;' onclick='approveForm(event)'> </i>
+                <i class='cancel fa fa-fw fa-ban' style='display:none;' onclick='cancelNewUser(event)'> </i>
+              </div>
+            </form>
+          <% end %>
         </div>
       </div>
     </div>

--- a/lib/server/views/project.html.erb
+++ b/lib/server/views/project.html.erb
@@ -4,26 +4,63 @@
   <%= erb_partial(:header) %>
   <script type='text/javascript'>
 
-const show = function(...elements) { elements.forEach( e => e.style = 'display:inline;'); }
-const hide = function(...elements) { elements.forEach( e => e.style = 'display:none;'); }
+const show = (form) => form.querySelectorAll('i').forEach(
+  e => e.style = 'display:inline;'
+);
+const hide = (form) => form.querySelectorAll('i').forEach(
+  e => e.style = 'display:none;'
+);
+
+const INPUTS = {
+  select: {
+    selector: (name) => `select[name="${name}"]`,
+    changed: (input, original) => original ? (input.value != original.value) : (input.value != 'none'),
+    reset: (input, original) => input.value = original ? original.value : 'none'
+  },
+  text: {
+    selector: (name) => `input[type="text"][name="${name}"]`,
+    changed: (input, original) => original ? (input.value != original.value) : (input.value.length > 0),
+    reset: (input, original) => input.value = original ? original.value : ''
+  },
+  checkbox: {
+    selector: (name) => `input[type="checkbox"][name="${name}"]`,
+    changed: (input, original) => input.checked.toString() != original.value,
+    reset: (input, original) => input.checked = original.value == 'true'
+  }
+};
+
+const inputsChanged = (form, inputs) =>
+  Object.keys(inputs).some(type =>
+    inputs[type].some(name =>
+      INPUTS[type].changed(
+        form.querySelector(INPUTS[type].selector(name)),
+        form.querySelector(`input[name="original_${name}"]`)
+      )
+    )
+  );
+
+const resetInputs = (form, inputs) =>
+  Object.keys(inputs).forEach(type =>
+    inputs[type].forEach(name =>
+      INPUTS[type].reset(
+        form.querySelector(INPUTS[type].selector(name)),
+        form.querySelector(`input[name="original_${name}"]`)
+      )
+    )
+  );
+
+const PERMISSION_INPUTS = {
+  select: [ 'role' ],
+  checkbox: [ 'privileged' ],
+  text: [ 'affiliation' ]
+};
 
 const updatePermission = function(e) {
   let select = e.target;
   let form = select.closest('.item');
 
-  let role = form.querySelector('select[name="role"]');
-  let original_role = form.querySelector('input[name="original_role"]');
-  let privileged = form.querySelector('input[type="checkbox"][name="privileged"]');
-  let original_privileged = form.querySelector('input[name="original_privileged"]');
-
-  let approve = form.querySelector('.approve');
-  let cancel = form.querySelector('.cancel');
-
-  if ((role && original_role.value != role.value) || original_privileged.value != privileged.checked.toString()) {
-    show(approve,cancel);
-  } else {
-    hide(approve,cancel);
-  }
+  if (inputsChanged(form, PERMISSION_INPUTS)) show(form);
+  else hide(form);
 }
 
 const approveForm = function(e) {
@@ -37,52 +74,29 @@ const cancelPermission = function(e) {
   let select = e.target;
   let form = select.closest('.item');
 
-  let role = form.querySelector('select[name="role"]');
-  let original_role = form.querySelector('input[name="original_role"]');
-  let privileged = form.querySelector('input[type="checkbox"][name="privileged"]');
-  let original_privileged = form.querySelector('input[name="original_privileged"]');
-
-  let approve = form.querySelector('.approve');
-  let cancel = form.querySelector('.cancel');
-
-  role.value = original_role.value;
-  privileged.checked = original_privileged.value == 'true';
-  hide(approve,cancel);
+  resetInputs(form, PERMISSION_INPUTS);
+  hide(form);
 }
+
+const NEWUSER_INPUTS = {
+  select: [ 'role' ],
+  text: [ 'name', 'email' ]
+};
 
 const updateNewUser = function(e) {
   let select = e.target;
   let form = select.closest('.item');
 
-  let name = form.querySelector('input[name="name"]');
-  let email = form.querySelector('input[name="email"]');
-  let role = form.querySelector('select[name="role"]');
-
-  let approve = form.querySelector('.approve');
-  let cancel = form.querySelector('.cancel');
-
-  if (role.value != 'none' && name.value.length > 0 && email.value.match(/.+\@.+\..+/)) {
-    show(approve,cancel);
-  } else {
-    hide(approve,cancel);
-  }
+  if (inputsChanged(form, NEWUSER_INPUTS)) show(form);
+  else hide(form);
 }
 
 const cancelNewUser = function(e) {
   let select = e.target;
   let form = select.closest('.item');
 
-  let name = form.querySelector('input[name="name"]');
-  let email = form.querySelector('input[name="email"]');
-  let role = form.querySelector('select[name="role"]');
-
-  let approve = form.querySelector('.approve');
-  let cancel = form.querySelector('.cancel');
-
-  name.value = '';
-  email.value = '';
-  role.value = 'none';
-  hide(approve,cancel);
+  resetInputs(form, NEWUSER_INPUTS);
+  hide(form);
 }
   </script>
   <body>
@@ -104,6 +118,7 @@ const cancelNewUser = function(e) {
             <div class='cell'>Name</div>
             <div class='cell'>Email</div>
             <div class='cell'>Role</div>
+            <div class='cell'>Affiliation</div>
             <div class='cell'>Privileged</div>
             <div class='cell submit'></div>
           </div>
@@ -122,11 +137,19 @@ const cancelNewUser = function(e) {
                 <% unless @roles.include?(permission.role) %>
                   <%= permission.role %>
                 <% else %>
-                  <select name='role' onchange='updatePermission(event)'>
+                  <select name='role' oninput='updatePermission(event)'>
                     <% @roles.each do |role| %>
                       <option value='<%= role %>' <%= role == permission.role.to_s ? 'selected' : '' %>><%= role %></option>
                     <% end %>
                   </select>
+                <% end %>
+              </div>
+              <div class='cell'>
+                <% if !@static %>
+                  <input type='hidden' name='original_affiliation' value='<%= permission.affiliation %>'>
+                  <input type='text' name='affiliation' value='<%= permission.affiliation %>' oninput='updatePermission(event)'>
+                <% else %>
+                  <%= permission.affiliation %>
                 <% end %>
               </div>
               <div class='cell'>
@@ -135,7 +158,7 @@ const cancelNewUser = function(e) {
                 <% else %>
                   <input type='hidden' name='original_privileged' value='<%= permission.privileged? ? 'true' : 'false' %>'>
                   <input type='hidden' name='privileged' value='false'>
-                  <input type='checkbox' name='privileged' value='true' <%= permission.privileged? ? 'checked' : '' %> onchange='updatePermission(event)'>
+                  <input type='checkbox' name='privileged' value='true' <%= permission.privileged? ? 'checked' : '' %> oninput='updatePermission(event)'>
                 <% end %>
               </div>
               <div class='cell submit'>
@@ -147,15 +170,16 @@ const cancelNewUser = function(e) {
           <% if !@static %>
             <div class='new'>New User</div>
             <form method='post' action='/add_user/<%= @project.project_name %>' class='item'>
-              <div class='cell'><input type='text' onchange='updateNewUser(event)' placeholder='Name' name='name'></div>
-              <div class='cell'><input type='text' onchange='updateNewUser(event)' placeholder='Email' name='email'></div>
+              <div class='cell'><input type='text' oninput='updateNewUser(event)' placeholder='Name' name='name'></div>
+              <div class='cell'><input type='text' oninput='updateNewUser(event)' placeholder='Email' name='email'></div>
               <div class='cell'>
-                <select onchange='updateNewUser(event)' name='role'>
+                <select oninput='updateNewUser(event)' name='role'>
                   <option selected value='none'>Role</option>
                   <option value='viewer'>Viewer</option>
                   <option value='editor'>Editor</option>
                 </select>
               </div>
+              <div class='cell'><input type='text' oninput='updateNewUser(event)' placeholder='Affiliation' name='affiliation'></div>
               <div class='cell'></div>
               <div class='cell submit'>
                 <i class='approve fa fa-fw fa-save' style='display:none;' onclick='approveForm(event)'> </i>

--- a/spec/admin_spec.rb
+++ b/spec/admin_spec.rb
@@ -53,13 +53,26 @@ describe AdminController do
       expect(last_response.status).to eq(200)
     end
 
-    it 'forbids the project view to non-admins' do
+    it 'shows a static project view to editors' do
       user = create(:user, first_name: 'Portunus', email: 'portunus@two-faces.org')
 
       door = create(:project, project_name: 'door', project_name_full: 'Door')
       perm = create(:permission, project: door, user: user, role: 'editor')
 
       auth_header(:portunus)
+      get('/project/door')
+
+      expect(last_response.status).to eq(200)
+      expect(html_body.css('input')).to be_empty
+    end
+
+    it 'forbids the project view to viewers' do
+      user = create(:user, first_name: 'Lar', last_name: 'Familiaris', email: 'lar@two-faces.org')
+
+      door = create(:project, project_name: 'door', project_name_full: 'Door')
+      perm = create(:permission, project: door, user: user, role: 'viewer')
+
+      auth_header(:lar)
       get('/project/door')
 
       expect(last_response.status).to eq(403)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'factory_bot'
 require 'database_cleaner'
 require 'simplecov'
 require 'timecop'
+require 'nokogiri'
 
 require_relative '../lib/janus'
 require_relative '../lib/server'
@@ -21,6 +22,9 @@ AUTH_USERS.update(
   },
   portunus: {
     email: 'portunus@two-faces.org', first: 'Portunus', perm: 'e:door'
+  },
+  lar: {
+    email: 'lar@two-faces.org', first: 'Lar', last: 'Familiaris', perm: 'v:door'
   }
 
 )
@@ -181,6 +185,10 @@ end
 
 def json_body(response=nil)
   JSON.parse((response || last_response).body, symbolize_names: true)
+end
+
+def html_body(response=nil)
+  Nokogiri::HTML((response ||last_response).body)
 end
 
 def json_post endpoint, hash


### PR DESCRIPTION
This does three things:

1) It adds an 'affiliation' string field to the permission model, allowing the admin to note the user's affiliation.

2) It allows editors to see a read-only version of the project page.

3) It adds a small text filter to more easily search the project permissions.