### PR TITLE
Graft secure cookies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    etna (0.1.6)
+    etna (0.1.7)
       jwt
       rack
     factory_bot (5.0.2)
@@ -23,7 +24,7 @@ GEM
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
     pry (0.12.2)
@@ -48,7 +49,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sequel (5.22.0)
+    sequel (5.24.0)
     simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -58,6 +59,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    zeitwerk (2.1.10)
 
 PLATFORMS
   ruby

--- a/config.ru
+++ b/config.ru
@@ -7,6 +7,7 @@ Bundler.require(:default, ENV["JANUS_ENV"].to_sym)
 require_relative './lib/janus'
 require_relative './lib/server'
 require_relative './lib/server/throttle'
+require_relative './lib/server/refresh_token'
 
 
 Janus.instance.configure(YAML.load(File.read('config.yml')))
@@ -16,4 +17,5 @@ use Rack::Static, urls: ['/css', '/js', '/fonts', '/img'], root: 'lib/client'
 use Etna::Auth
 
 use Janus::Throttle, max: 100
+use Janus::RefreshToken
 run Janus::Server.new

--- a/lib/janus.rb
+++ b/lib/janus.rb
@@ -11,4 +11,27 @@ class Janus
 
     require_relative 'models' if load_models
   end
+
+  def set_token_cookie(response,token)
+    # Tear apart token to get expire time
+    expire_time = Time.at(
+      JSON.parse(
+        Base64.decode64(
+          token.split('.')[1]
+        )
+      )["exp"]
+    )
+
+    # Set cookie
+    response.set_cookie(
+      config(:token_name),
+      value: token,
+      path: '/',
+      domain: config(:token_domain),
+      expires: expire_time,
+      secure: true,
+      same_site: :strict
+    )
+  end
+
 end

--- a/lib/server/controllers/authorization_controller.rb
+++ b/lib/server/controllers/authorization_controller.rb
@@ -123,26 +123,7 @@ class AuthorizationController < Janus::Controller
     # Set redirect.
     @response.redirect(refer, 302)
 
-    # Tear apart token to get expire time
-    expire_time = Time.at(
-      JSON.parse(
-        Base64.decode64(
-          token.split('.')[1]
-        )
-      )["exp"]
-    )
-
-    # Set cookie
-    @response.set_cookie(
-      Janus.instance.config(:token_name),
-      value: token,
-      path: '/',
-      domain: Janus.instance.config(:token_domain),
-      expires: expire_time,
-      secure: true,
-      same_site: :strict
-    )
-
+    Janus.instance.set_token_cookie(@response,token)
     return @response.finish
   end
 

--- a/lib/server/controllers/authorization_controller.rb
+++ b/lib/server/controllers/authorization_controller.rb
@@ -138,7 +138,9 @@ class AuthorizationController < Janus::Controller
       value: token,
       path: '/',
       domain: Janus.instance.config(:token_domain),
-      expires: expire_time
+      expires: expire_time,
+      secure: true,
+      same_site: :strict
     )
 
     return @response.finish

--- a/lib/server/nonce.rb
+++ b/lib/server/nonce.rb
@@ -1,5 +1,11 @@
+require 'openssl'
+
 class Janus
   class Nonce
+    def self.nonce_key
+      @nonce_key ||= OpenSSL::PKey::RSA.new(2048)
+    end
+
     def self.valid?(nonce)
       timestamp, nonce_sig = Base64.decode64(nonce).split(/\./)
 
@@ -22,8 +28,8 @@ class Janus
     end
 
     def to_s
-      # sign the time with our private key
-      signature = Janus.instance.sign.private_key.sign(
+      # sign the time with our nonce key
+      signature = Janus::Nonce.nonce_key.sign(
         OpenSSL::Digest::SHA256.new,
         @timestamp
       )

--- a/lib/server/refresh_token.rb
+++ b/lib/server/refresh_token.rb
@@ -1,0 +1,40 @@
+class Janus
+  class RefreshToken
+    def initialize(app)
+      @app = app
+    end
+
+    def cookie_response(token, status, headers, body)
+      response = Rack::Response.new(body, status, headers)
+
+      Janus.instance.set_token_cookie(response, token)
+
+      return response.finish
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+
+      return @app.call(env) unless request.path == '/'
+
+      Janus.instance.tap do |janus|
+
+        existing_token = request.cookies[janus.config(:token_name)]
+
+        return @app.call(env) if !existing_token || !request.env['etna.user']
+
+        janus_user = User[email: request.env['etna.user'].email]
+
+        return [ 401, { 'Content-Type' => 'application/json' }, [ { error: 'Unknown user in token' }.to_json ] ] unless janus_user
+
+        payload = JSON.parse(
+          Base64.decode64(existing_token.split(/\./)[1]), symbolize_names: true
+        ).reject{|k|k == :exp}
+
+        return @app.call(env) if payload == janus_user.jwt_payload
+
+        return cookie_response(janus_user.create_token!, *@app.call(env))
+      end
+    end
+  end
+end

--- a/spec/login_spec.rb
+++ b/spec/login_spec.rb
@@ -4,9 +4,6 @@ describe AuthorizationController do
   def app
     OUTER_APP
   end
-  before(:each) do
-    @client = create(:app, app_name: 'test', app_key: 'THE KEY')
-  end
 
   context 'password login' do
     before(:each) do
@@ -70,7 +67,6 @@ describe AuthorizationController do
         'validate-login', 
         email: @user.email,
         password: 'bassboard',
-        app_key: @client.app_key,
         refer: @refer
       )
       expect(last_response.status).to eq(422)
@@ -81,7 +77,6 @@ describe AuthorizationController do
         'validate-login', 
         email: @user.email,
         password: 'password',
-        app_key: @client.app_key,
         refer: @refer
       )
       expect(last_response.status).to eq(302)
@@ -110,7 +105,6 @@ describe AuthorizationController do
           'validate-login', 
           email: @user.email,
           password: 'password',
-          app_key: @client.app_key,
           refer: @refer
         )
         cookies = parse_cookie(last_response.headers['Set-Cookie'])
@@ -134,7 +128,6 @@ describe AuthorizationController do
           'validate-login', 
           email: @user.email,
           password: 'password',
-          app_key: @client.app_key,
           refer: @refer
         )
         cookies = parse_cookie(last_response.headers['Set-Cookie'])
@@ -150,7 +143,6 @@ describe AuthorizationController do
         'validate-login', 
         email: @user.email,
         password: @password,
-        app_key: @client.app_key,
         refer: @refer
       )
 
@@ -164,7 +156,6 @@ describe AuthorizationController do
         'validate-login', 
         email: @user.email,
         password: @password,
-        app_key: @client.app_key,
         refer: refer
       )
       expect(rack_mock_session.cookie_jar[Janus.instance.config(:token_name)]).not_to be_empty

--- a/spec/refresh_token_spec.rb
+++ b/spec/refresh_token_spec.rb
@@ -1,0 +1,53 @@
+describe Janus::RefreshToken do
+  include Rack::Test::Methods
+
+  def app
+    OUTER_APP
+  end
+
+  before(:each) do
+    @user = create(
+      :user,
+      email: 'janus@two-faces.org',
+      first_name: 'Janus', last_name: 'Bifrons'
+    )
+    gateway = create(:project, project_name: 'gateway', project_name_full: 'Gateway')
+    @perm = create(:permission, project: gateway, user: @user, role: 'viewer')
+
+    @token = @user.create_token!
+
+    set_cookie([ Janus.instance.config(:token_name), @token ].join('='))
+  end
+
+  it 'updates an out-of-date token' do
+    @perm.role = 'editor'
+    @perm.save
+
+    @user.refresh
+    new_token = @user.create_token!
+
+    # the token has changed
+    expect(new_token).not_to eq(@token)
+
+    # we visit janus
+    auth_header(:janus)
+    get('/')
+
+    expect(last_response.status).to eq(200)
+
+    # a new cookie is set with the new token
+    cookies = parse_cookie(last_response.headers['Set-Cookie'])
+    expect(cookies[Janus.instance.config(:token_name)]).to eq(new_token)
+  end
+
+  it 'ignores an up-to-date token' do
+    # we visit janus
+    auth_header(:janus)
+    get('/')
+
+    expect(last_response.status).to eq(200)
+
+    # there is no cookie set
+    expect(last_response.headers['Set-Cookie']).to be_nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'nokogiri'
 require_relative '../lib/janus'
 require_relative '../lib/server'
 require_relative '../lib/server/throttle'
+require_relative '../lib/server/refresh_token'
 
 ENV['JANUS_ENV'] = 'test'
 
@@ -37,10 +38,11 @@ JANUS_URL="https://#{JANUS_HOST}"
 OUTER_APP = Rack::Builder.new do
   use Etna::ParseBody
   use Etna::SymbolizeParams
+  use Etna::TestAuth
   use Rack::Static, urls: ['/css', '/js', '/fonts', '/img'], root: 'lib/client'
 
   use Janus::Throttle, max: 100
-  use Etna::TestAuth
+  use Janus::RefreshToken
   run Janus::Server.new
 end
 
@@ -235,6 +237,6 @@ def config
   Janus.instance.instance_variable_get("@config")
 end
 
-def parse_cookie set_cookie
+def parse_cookie(set_cookie='')
   Hash[set_cookie.split(/; /).map { |param| param.split(/=/) }]
 end


### PR DESCRIPTION
Janus cookie-setting is in an abysmal state vulnerable to several issues, most significant being that it is transmitted to any host in the token domain, even without ssl. Though etna services are on https, tokens may still be sent in cleartext this way if someone visits any http service. This PR cleans this up by setting the 'same-site' policy to strict and setting the 'secure' attribute.

Also added: a "refresh token" which issues a new token for a given user if their current (but valid) one is out of date.