### PR TITLE
escape html for affiliation

### DIFF
--- a/lib/server/controllers/janus_controller.rb
+++ b/lib/server/controllers/janus_controller.rb
@@ -13,6 +13,10 @@ class Janus
       success(hash.to_json, 'application/json')
     end
 
+    def h(s)
+      ERB::Util.html_escape(s)
+    end
+
     # Quick check that the email is in a somewhat valid format.
     def email_valid?(eml)
       eml =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/

--- a/lib/server/views/project.html.erb
+++ b/lib/server/views/project.html.erb
@@ -147,12 +147,12 @@ const filter = (e) => {
               <div class='cell'><span class='name'><%= permission.user.name %></span></div>
               <div class='cell'>
                 <% if !@static %>
-                  <input type='hidden' name='email' value='<%= permission.user.email %>'>
+                  <input type='hidden' name='email' value='<%= h(permission.user.email) %>'>
                 <% end %>
                 <span class='email'><%= permission.user.email %></span></div>
               <div class='cell'>
                 <% if !@static %>
-                  <input type='hidden' name='original_role' value='<%= permission.role %>'>
+                  <input type='hidden' name='original_role' value='<%= h(permission.role) %>'>
                 <% end %>
                 <% unless @roles.include?(permission.role) %>
                   <span class='role'><%= permission.role %></span>
@@ -166,10 +166,10 @@ const filter = (e) => {
               </div>
               <div class='cell'>
                 <% if !@static %>
-                  <input type='hidden' name='original_affiliation' value='<%= permission.affiliation %>'>
-                  <input class='affiliation' type='text' name='affiliation' value='<%= permission.affiliation %>' oninput='updatePermission(event)'>
+                  <input type='hidden' name='original_affiliation' value='<%= h(permission.affiliation) %>'>
+                  <input class='affiliation' type='text' name='affiliation' value='<%= h(permission.affiliation) %>' oninput='updatePermission(event)'>
                 <% else %>
-                  <span class='affiliation'><%= permission.affiliation %></span>
+                  <span class='affiliation'><%= h(permission.affiliation) %></span>
                 <% end %>
               </div>
               <div class='cell'>


### PR DESCRIPTION
A wee tweak in case someone puts in an affiliation with a single-quote in it; it needs to be escaped.