### PR TITLE
add unique constraint to permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '2.5.7'
 
 gem 'rack'
 gem 'rack-throttle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.0)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.1, >= 2.1.8)
-    coderay (1.1.2)
-    concurrent-ruby (1.1.5)
-    connection_pool (2.2.2)
-    database_cleaner (1.7.0)
-    diff-lcs (1.3)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.6)
+    connection_pool (2.2.3)
+    database_cleaner (1.8.5)
+    diff-lcs (1.4.4)
     docile (1.3.2)
-    etna (0.1.11)
+    etna (0.1.13)
       jwt
       multipart-post
       net-http-persistent
       rack
-    factory_bot (5.1.1)
-      activesupport (>= 4.2.0)
-    i18n (1.7.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    json (2.2.0)
     jwt (2.2.1)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_portile2 (2.4.0)
-    minitest (5.12.2)
+    minitest (5.14.1)
     multipart-post (2.1.1)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    pg (1.1.4)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rack (2.0.7)
+    pg (1.2.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-throttle (0.7.0)
@@ -46,26 +45,25 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
-    rspec-expectations (3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
-    sequel (5.25.0)
-    simplecov (0.17.1)
+    rspec-support (3.9.3)
+    sequel (5.34.0)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    zeitwerk (2.2.0)
+    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby
@@ -87,7 +85,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.7p206
 
 BUNDLED WITH
-   1.16.5
+   2.1.4

--- a/db/migrations/006_add_unique_to_permissions.rb
+++ b/db/migrations/006_add_unique_to_permissions.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:permissions) do
+      add_index [:user_id, :project_id], unique: true
+    end
+  end
+end


### PR DESCRIPTION
The permissions table wasn't constrained to require that it be unique for (user_id,project_id), which is bad - no one should have two roles on a project! Normally this isn't an issue, since the admin_controller catches this sort of thing, but a table constraint is a nice safety-check.

Also, sneakily, upgrading Ruby to 2.5.7 which apparently hasn't been done on Janus yet?